### PR TITLE
KYC, Presale, Pausable Added

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015", "stage-1"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -38,7 +38,14 @@
         // react
         "react/prefer-es6-class": 0,
         "react/jsx-filename-extension": 0,
-        "react/jsx-indent": [ 2, 4 ]
+        "react/jsx-indent": [ 2, 4 ],
+
+        // plc
+        "no-await-in-loop": "off",
+        "no-restricted-syntax": "off",
+        "no-mixed-operators": "off",
+        "one-var-declaration-per-line": ["error", "initializations"],
+        "one-var": "off"
     },
     "globals": {
         "artifacts": true,

--- a/contracts/KYC.sol
+++ b/contracts/KYC.sol
@@ -10,21 +10,30 @@ import './lifecycle/Pausable.sol';
  */
 contract KYC is Ownable, SafeMath, Pausable {
   mapping (address => bool)    public knownAddress;
-  mapping (address => uint256) public knownPreSaledAmount;
+  mapping (bytes32 => address) public knownKey;
+  mapping (address => uint256) public knownPreSaledEtherAmount;
 
-  event AddressAdded(address indexed _addr);
-  event AddressPreSaled(address indexed _addr, uint256 _amount);
+  event AddressAdded(bytes32 indexed _key, address indexed _addr);
+  event AddressPreSaled(bytes32 indexed _key, address indexed _addr, uint256 _amount);
 
-  function addUser(address _addr) public onlyOwner whenNotPaused {
+  function addUser(bytes32 _key, address _addr) public onlyOwner whenNotPaused {
+    require(_key != bytes32(0) && knownKey[_key] == address(0));
+    require(_addr != address(0) && knownAddress[_addr] == false);
+
     knownAddress[_addr] = true;
-    AddressAdded(_addr);
+    knownKey[_key] = _addr;
+    AddressAdded(_key, _addr);
   }
 
-  function addUserWithPreSale(address _addr, uint256 _amount) public onlyOwner whenNotPaused {
+  function addUserWithPreSale(bytes32 _key, address _addr, uint256 _amount) public onlyOwner whenNotPaused {
+    require(_key != bytes32(0) && knownKey[_key] == address(0));
+    require(_addr != address(0) && knownAddress[_addr] == false);
+
     knownAddress[_addr] = true;
-    AddressAdded(_addr);
-    
-    knownPreSaledAmount[_addr] = _amount;
-    AddressPreSaled(_addr, _amount);
+    knownKey[_key] = _addr;
+    AddressAdded(_key, _addr);
+
+    knownPreSaledEtherAmount[_addr] = _amount;
+    AddressPreSaled(_key, _addr, _amount);
   }
 }

--- a/contracts/KYC.sol
+++ b/contracts/KYC.sol
@@ -9,31 +9,129 @@ import './lifecycle/Pausable.sol';
  * @dev KYC
  */
 contract KYC is Ownable, SafeMath, Pausable {
-  mapping (address => bool)    public knownAddress;
-  mapping (bytes32 => address) public knownKey;
-  mapping (address => uint256) public knownPreSaledEtherAmount;
+  mapping (address => bool)    public registeredAddress;
+  mapping (bytes32 => address) public registeredKey;
+  mapping (address => uint256) public registeredAmount;
 
-  event AddressAdded(bytes32 indexed _key, address indexed _addr);
-  event AddressPreSaled(bytes32 indexed _key, address indexed _addr, uint256 _amount);
+  event Registered(address indexed _addr);
+  event RegisteredWithPreSale(address indexed _addr, uint256 _amount);
 
-  function addUser(bytes32 _key, address _addr) public onlyOwner whenNotPaused {
-    require(_key != bytes32(0) && knownKey[_key] == address(0));
-    require(_addr != address(0) && knownAddress[_addr] == false);
+  event RegisteredWithKey(bytes32 indexed _key, address indexed _addr);
+  event RegisteredWithKeyAndPreSale(bytes32 indexed _key, address indexed _addr, uint256 _amount);
 
-    knownAddress[_addr] = true;
-    knownKey[_key] = _addr;
-    AddressAdded(_key, _addr);
+  event Unregistered(address indexed _addr);
+  event UnregisteredWithKey(bytes32 indexed _key, address indexed _addr);
+
+  modifier onlyRegistered(address _addr) {
+    require(isRegistered(_addr));
+    _;
   }
 
-  function addUserWithPreSale(bytes32 _key, address _addr, uint256 _amount) public onlyOwner whenNotPaused {
-    require(_key != bytes32(0) && knownKey[_key] == address(0));
-    require(_addr != address(0) && knownAddress[_addr] == false);
-
-    knownAddress[_addr] = true;
-    knownKey[_key] = _addr;
-    AddressAdded(_key, _addr);
-
-    knownPreSaledEtherAmount[_addr] = _amount;
-    AddressPreSaled(_key, _addr, _amount);
+  modifier onlyRegisteredWithKey(bytes32 _key, address _addr) {
+    require(isRegisteredWithKey(_key, _addr));
+    _;
   }
+
+  function getAddress(bytes32 _key) public constant returns (address) {
+    return registeredKey[_key];
+  }
+
+  function isRegistered(address _addr) public constant returns (bool) {
+    return registeredAddress[_addr];
+  }
+
+  function isRegisteredWithKey(bytes32 _key, address _addr) public constant  returns (bool) {
+    return registeredAddress[_addr] && registeredKey[_key] == _addr;
+  }
+
+  function register(address _addr)
+    public
+    onlyOwner
+    whenNotPaused
+  {
+    require(_addr != address(0) && registeredAddress[_addr] == false);
+
+    registeredAddress[_addr] = true;
+
+    Registered(_addr);
+  }
+
+  // register account with key and presale
+  function registerWithPreSale(
+    address _addr,
+    uint256 _amount)
+    public
+    onlyOwner
+    whenNotPaused
+  {
+    require(_addr != address(0) && registeredAddress[_addr] == false);
+
+    registeredAddress[_addr] = true;
+    registeredAmount[_addr] = _amount;
+
+    RegisteredWithPreSale(_addr, _amount);
+  }
+
+  // register account with key
+  function registerWithKey(
+    bytes32 _key,
+    address _addr)
+    public
+    onlyOwner
+    whenNotPaused
+  {
+    require(_key != bytes32(0) && registeredKey[_key] == address(0));
+    require(_addr != address(0) && registeredAddress[_addr] == false);
+
+    registeredAddress[_addr] = true;
+    registeredKey[_key] = _addr;
+
+    RegisteredWithKey(_key, _addr);
+  }
+
+  // register account with key and presale
+  function registerWithKeyAndPreSale(
+    bytes32 _key,
+    address _addr,
+    uint256 _amount)
+    public
+    onlyOwner
+    whenNotPaused
+  {
+    require(_key != bytes32(0) && registeredKey[_key] == address(0));
+    require(_addr != address(0) && registeredAddress[_addr] == false);
+
+    registeredAddress[_addr] = true;
+    registeredKey[_key] = _addr;
+    registeredAmount[_addr] = _amount;
+
+    RegisteredWithKeyAndPreSale(_key, _addr, _amount);
+  }
+
+  function unregisterUser(
+    address _addr)
+    public
+    onlyOwner
+    onlyRegistered(_addr)
+  {
+    registeredAddress[_addr] = false;
+    registeredAmount[_addr] = 0;
+
+    Unregistered(_addr);
+  }
+
+  function unregisterUserWithKey(
+    bytes32 _key,
+    address _addr)
+    public
+    onlyOwner
+    onlyRegisteredWithKey(_key, _addr)
+  {
+    registeredKey[_key] = address(0);
+    registeredAddress[_addr] = false;
+    registeredAmount[_addr] = 0;
+
+    UnregisteredWithKey(_key, _addr);
+  }
+
 }

--- a/contracts/KYC.sol
+++ b/contracts/KYC.sol
@@ -20,7 +20,10 @@ contract KYC is Ownable, SafeMath, Pausable {
     AddressAdded(_addr);
   }
 
-  function preSaled(address _addr, uint256 _amount) public onlyOwner whenNotPaused {
+  function addUserWithPreSale(address _addr, uint256 _amount) public onlyOwner whenNotPaused {
+    knownAddress[_addr] = true;
+    AddressAdded(_addr);
+    
     knownPreSaledAmount[_addr] = _amount;
     AddressPreSaled(_addr, _amount);
   }

--- a/contracts/KYC.sol
+++ b/contracts/KYC.sol
@@ -1,0 +1,27 @@
+pragma solidity ^0.4.11;
+
+import './math/SafeMath.sol';
+import './ownership/Ownable.sol';
+import './lifecycle/Pausable.sol';
+
+/**
+ * @title KYC
+ * @dev KYC
+ */
+contract KYC is Ownable, SafeMath, Pausable {
+  mapping (address => bool)    public knownAddress;
+  mapping (address => uint256) public knownPreSaledAmount;
+
+  event AddressAdded(address indexed _addr);
+  event AddressPreSaled(address indexed _addr, uint256 _amount);
+
+  function addUser(address _addr) public onlyOwner whenNotPaused {
+    knownAddress[_addr] = true;
+    AddressAdded(_addr);
+  }
+
+  function preSaled(address _addr, uint256 _amount) public onlyOwner whenNotPaused {
+    knownPreSaledAmount[_addr] = _amount;
+    AddressPreSaled(_addr, _amount);
+  }
+}

--- a/contracts/PLCCrowdsale.sol
+++ b/contracts/PLCCrowdsale.sol
@@ -4,6 +4,8 @@ import './math/SafeMath.sol';
 import './ownership/Ownable.sol';
 import './PLC.sol';
 import './crowdsale/RefundVault.sol';
+import './lifecycle/Pausable.sol';
+import './KYC.sol';
 
 /**
  * @title PLCCrowdsale
@@ -13,7 +15,7 @@ import './crowdsale/RefundVault.sol';
  * on a token per ETH rate. Funds collected are forwarded to a wallet
  * as they arrive.
  */
-contract PLCCrowdsale is Ownable, SafeMath {
+contract PLCCrowdsale is Ownable, SafeMath, Pausable, KYC {
 
   // The token being sold
   PLC public token;
@@ -23,6 +25,8 @@ contract PLCCrowdsale is Ownable, SafeMath {
   uint64 public endTime = 1507593600; //2017.10.10 12:00 am (UTC)
 
   uint64[5] public deadlines = [1506643200, 1506902400, 1507161600, 1507420800, 1507593600]; // [2017.9.26, 2017.10.02, 2017.10.05, 2017.10.08, 2017.10.10]
+
+  uint8 presaleRate = uint8(500);
 	uint8[5] public rates = [240, 230, 220, 210, 200];
 
   // amount of raised money in wei

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -29,4 +29,20 @@ contract SafeMath {
     assert(c >= a);
     return c;
   }
+
+  function max64(uint64 a, uint64 b) internal constant returns (uint64) {
+    return a >= b ? a : b;
+  }
+
+  function min64(uint64 a, uint64 b) internal constant returns (uint64) {
+    return a < b ? a : b;
+  }
+
+  function max256(uint256 a, uint256 b) internal constant returns (uint256) {
+    return a >= b ? a : b;
+  }
+
+  function min256(uint256 a, uint256 b) internal constant returns (uint256) {
+    return a < b ? a : b;
+  }
 }

--- a/migrations/2_PLC_migration.js
+++ b/migrations/2_PLC_migration.js
@@ -2,6 +2,7 @@ const PLCCrowdsale = artifacts.require("PLCCrowdsale.sol");
 const PLC = artifacts.require("PLC.sol");
 const RefundVault = artifacts.require("crowdsale/RefundVault.sol");
 const MultiSig = artifacts.require("wallet/MultiSigWallet.sol");
+const KYC = artifacts.require("KYC.sol");
 
 module.exports = async function (deployer, network, accounts) {
   const reserveWallet = accounts.slice(3, 3 + 5);
@@ -15,8 +16,19 @@ module.exports = async function (deployer, network, accounts) {
   const vault = await RefundVault.new(multiSig.address, reserveWallet);
   console.log("vault deployed at", vault.address);
 
-  const crowdsale = await PLCCrowdsale.new(token.address, vault.address, multiSig.address, reserveWallet);
+  /*eslint-disable */
+  const crowdsale = await PLCCrowdsale.new(
+    token.address,
+    vault.address,
+    multiSig.address,
+    reserveWallet
+  );
+  /*eslint-enable */
+
   console.log("crowdsale deployed at", crowdsale.address);
+
+  const kyc = await KYC.new();
+  console.log("kyc deployed at", kyc.address);
 
   await token.transferOwnership(crowdsale.address);
   await vault.transferOwnership(crowdsale.address);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "babel-eslint": "^7.2.3",
     "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
+    "babel-preset-stage-1": "^6.24.1",
     "babel-register": "^6.26.0",
     "chai": "^4.1.1",
     "chai-as-promised": "^7.1.1",

--- a/test/KYCTest.js
+++ b/test/KYCTest.js
@@ -23,105 +23,329 @@ contract("KYC", async ([ owner, , , , , , , , ...accounts ]) => {
     kyc = await KYC.new();
   });
 
-  describe("Adding user", async () => {
-    const idx0 = accounts.length / 4;
-    const idx1 = accounts.length * 2 / 4;
-    const idx2 = accounts.length * 3 / 4;
-    const idx3 = accounts.length;
+  describe("Without key", async () => {
+    describe("Without presale", async () => {
+      const idx0 = accounts.length / 4;
+      const idx1 = accounts.length * 2 / 4;
+      const idx2 = accounts.length * 3 / 4;
+      const idx3 = accounts.length;
 
-    it("should add new user initially", async () => {
-      for (const account of accounts.slice(0, idx0)) {
-        const key = web3.sha3(Date.now() + account);
-        await kyc.addUser(key, account).should.be.fulfilled;
-      }
+      it("should register new user initially", async () => {
+        for (const account of accounts.slice(0, idx0)) {
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+
+          await kyc.register(account)
+            .should.be.fulfilled;
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+      });
+
+      it("should not register new user after paused", async () => {
+        await kyc.pause();
+
+        for (const account of accounts.slice(idx0, idx1)) {
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+
+          await kyc.register(account)
+            .should.be.rejectedWith(EVMThrow);
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+        }
+      });
+
+      it("should register new user after paused and unpaused", async () => {
+        await kyc.pause();
+        await kyc.unpause();
+
+        for (const account of accounts.slice(idx1, idx2)) {
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+
+          await kyc.register(account)
+            .should.be.fulfilled;
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+      });
+
+      it("should not register user who previously added with presale", async () => {
+        for (const account of accounts.slice(idx2, idx3)) {
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+
+          await kyc.register(account)
+            .should.be.fulfilled;
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+
+        for (const account of accounts.slice(idx2, idx3)) {
+          await kyc.register(account)
+            .should.be.rejectedWith(EVMThrow);
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+      });
     });
 
-    it("should not add new user after paused", async () => {
-      await kyc.pause();
+    describe("With presale", async () => {
+      const idx0 = accounts.length / 4;
+      const idx1 = accounts.length * 2 / 4;
+      const idx2 = accounts.length * 3 / 4;
+      const idx3 = accounts.length;
 
-      for (const account of accounts.slice(idx0, idx1)) {
-        const key = web3.sha3(Date.now() + account);
-        await kyc.addUser(key, account).should.be.rejectedWith(EVMThrow);
-      }
-    });
+      it("should register new user initially", async () => {
+        for (const account of accounts.slice(0, idx0)) {
+          const amount = ether(Math.floor(Math.random() * 4900));
 
-    it("should add new user after paused and unpaused", async () => {
-      await kyc.pause();
-      await kyc.unpause();
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
 
-      for (const account of accounts.slice(idx1, idx2)) {
-        const key = web3.sha3(Date.now() + account);
-        await kyc.addUser(key, account).should.be.fulfilled;
-      }
-    });
+          await kyc.registerWithPreSale(account, amount)
+            .should.be.fulfilled;
 
-    it("should not add user who previously added with presale", async () => {
-      for (const account of accounts.slice(idx2, idx3)) {
-        const key = web3.sha3(Date.now() + account);
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+      });
 
-        await kyc.addUser(key, account).should.be.fulfilled;
-      }
+      it("should not register new user after paused", async () => {
+        await kyc.pause();
 
-      for (const account of accounts.slice(idx2, idx3)) {
-        const key = web3.sha3(Date.now() + account);
+        for (const account of accounts.slice(idx0, idx1)) {
+          const amount = ether(Math.floor(Math.random() * 4900));
 
-        await kyc.addUser(key, account).should.be.rejectedWith(EVMThrow);
-      }
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+
+          await kyc.registerWithPreSale(account, amount)
+            .should.be.rejectedWith(EVMThrow);
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+        }
+      });
+
+      it("should register new user after paused and unpaused", async () => {
+        await kyc.pause();
+        await kyc.unpause();
+
+        for (const account of accounts.slice(idx1, idx2)) {
+          const amount = ether(Math.floor(Math.random() * 4900));
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+
+          await kyc.registerWithPreSale(account, amount)
+            .should.be.fulfilled;
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+      });
+
+      it("should not register user who previously added with presale", async () => {
+        for (const account of accounts.slice(idx2, idx3)) {
+          const amount = ether(Math.floor(Math.random() * 4900));
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+
+          await kyc.registerWithPreSale(account, amount)
+            .should.be.fulfilled;
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+
+        for (const account of accounts.slice(idx2, idx3)) {
+          const amount = ether(Math.floor(Math.random() * 4900));
+
+          await kyc.registerWithPreSale(account, amount)
+            .should.be.rejectedWith(EVMThrow);
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+      });
     });
   });
 
-  describe("Adding user with presaled", async () => {
-    const idx0 = accounts.length / 4;
-    const idx1 = accounts.length * 2 / 4;
-    const idx2 = accounts.length * 3 / 4;
-    const idx3 = accounts.length;
+  describe("With key", async () => {
+    describe("Without presale", async () => {
+      const idx0 = accounts.length / 4;
+      const idx1 = accounts.length * 2 / 4;
+      const idx2 = accounts.length * 3 / 4;
+      const idx3 = accounts.length;
 
-    it("should add new user initially", async () => {
-      for (const account of accounts.slice(0, idx0)) {
-        const key = web3.sha3(Date.now() + account);
-        const amount = ether(Math.floor(Math.random() * 4900));
+      it("should register new user initially", async () => {
+        for (const account of accounts.slice(0, idx0)) {
+          const key = web3.sha3(account);
 
-        await kyc.addUserWithPreSale(key, account, amount).should.be.fulfilled;
-      }
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+
+          await kyc.registerWithKey(key, account)
+            .should.be.fulfilled;
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+      });
+
+      it("should not register new user after paused", async () => {
+        await kyc.pause();
+
+        for (const account of accounts.slice(idx0, idx1)) {
+          const key = web3.sha3(account);
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+
+          await kyc.registerWithKey(key, account)
+            .should.be.rejectedWith(EVMThrow);
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+        }
+      });
+
+      it("should register new user after paused and unpaused", async () => {
+        await kyc.pause();
+        await kyc.unpause();
+
+        for (const account of accounts.slice(idx1, idx2)) {
+          const key = web3.sha3(account);
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+
+          await kyc.registerWithKey(key, account)
+            .should.be.fulfilled;
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+      });
+
+      it("should not register user who previously added with presale", async () => {
+        for (const account of accounts.slice(idx2, idx3)) {
+          const key = web3.sha3(account);
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+
+          await kyc.registerWithKey(key, account)
+            .should.be.fulfilled;
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+
+        for (const account of accounts.slice(idx2, idx3)) {
+          const key = web3.sha3(account);
+
+          await kyc.registerWithKey(key, account).should.be.rejectedWith(EVMThrow);
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+      });
     });
 
-    it("should not add new user after paused", async () => {
-      await kyc.pause();
+    describe("With presale", async () => {
+      const idx0 = accounts.length / 4;
+      const idx1 = accounts.length * 2 / 4;
+      const idx2 = accounts.length * 3 / 4;
+      const idx3 = accounts.length;
 
-      for (const account of accounts.slice(idx0, idx1)) {
-        const key = web3.sha3(Date.now() + account);
-        const amount = ether(Math.floor(Math.random() * 4900));
+      it("should register new user initially", async () => {
+        for (const account of accounts.slice(0, idx0)) {
+          const key = web3.sha3(account);
+          const amount = ether(Math.floor(Math.random() * 4900));
 
-        await kyc.addUserWithPreSale(key, account, amount).should.be.rejectedWith(EVMThrow);
-      }
-    });
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
 
-    it("should add new user after paused and unpaused", async () => {
-      await kyc.pause();
-      await kyc.unpause();
+          await kyc.registerWithKeyAndPreSale(key, account, amount)
+            .should.be.fulfilled;
 
-      for (const account of accounts.slice(idx1, idx2)) {
-        const key = web3.sha3(Date.now() + account);
-        const amount = ether(Math.floor(Math.random() * 4900));
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+      });
 
-        await kyc.addUserWithPreSale(key, account, amount).should.be.fulfilled;
-      }
-    });
+      it("should not register new user after paused", async () => {
+        await kyc.pause();
 
-    it("should not add user who previously added with presale", async () => {
-      for (const account of accounts.slice(idx2, idx3)) {
-        const key = web3.sha3(Date.now() + account);
-        const amount = ether(Math.floor(Math.random() * 4900));
+        for (const account of accounts.slice(idx0, idx1)) {
+          const key = web3.sha3(account);
+          const amount = ether(Math.floor(Math.random() * 4900));
 
-        await kyc.addUserWithPreSale(key, account, amount).should.be.fulfilled;
-      }
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
 
-      for (const account of accounts.slice(idx2, idx3)) {
-        const key = web3.sha3(Date.now() + account);
-        const amount = ether(Math.floor(Math.random() * 4900));
+          await kyc.registerWithKeyAndPreSale(key, account, amount)
+            .should.be.rejectedWith(EVMThrow);
 
-        await kyc.addUserWithPreSale(key, account, amount).should.be.rejectedWith(EVMThrow);
-      }
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+        }
+      });
+
+      it("should register new user after paused and unpaused", async () => {
+        await kyc.pause();
+        await kyc.unpause();
+
+        for (const account of accounts.slice(idx1, idx2)) {
+          const key = web3.sha3(account);
+          const amount = ether(Math.floor(Math.random() * 4900));
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+
+          await kyc.registerWithKeyAndPreSale(key, account, amount)
+            .should.be.fulfilled;
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+      });
+
+      it("should not register user who previously added with presale", async () => {
+        for (const account of accounts.slice(idx2, idx3)) {
+          const key = web3.sha3(account);
+          const amount = ether(Math.floor(Math.random() * 4900));
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(false);
+
+          await kyc.registerWithKeyAndPreSale(key, account, amount)
+            .should.be.fulfilled;
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+
+        for (const account of accounts.slice(idx2, idx3)) {
+          const key = web3.sha3(account);
+          const amount = ether(Math.floor(Math.random() * 4900));
+
+          await kyc.registerWithKeyAndPreSale(key, account, amount)
+            .should.be.rejectedWith(EVMThrow);
+
+          (await kyc.isRegistered(account))
+            .should.be.equal(true);
+        }
+      });
     });
   });
 });

--- a/test/KYCTest.js
+++ b/test/KYCTest.js
@@ -31,7 +31,8 @@ contract("KYC", async ([ owner, , , , , , , , ...accounts ]) => {
 
     it("should add new user initially", async () => {
       for (const account of accounts.slice(0, idx0)) {
-        await kyc.addUser(account).should.be.fulfilled;
+        const key = web3.sha3(Date.now() + account);
+        await kyc.addUser(key, account).should.be.fulfilled;
       }
     });
 
@@ -39,7 +40,8 @@ contract("KYC", async ([ owner, , , , , , , , ...accounts ]) => {
       await kyc.pause();
 
       for (const account of accounts.slice(idx0, idx1)) {
-        await kyc.addUser(account).should.be.rejectedWith(EVMThrow);
+        const key = web3.sha3(Date.now() + account);
+        await kyc.addUser(key, account).should.be.rejectedWith(EVMThrow);
       }
     });
 
@@ -48,7 +50,22 @@ contract("KYC", async ([ owner, , , , , , , , ...accounts ]) => {
       await kyc.unpause();
 
       for (const account of accounts.slice(idx1, idx2)) {
-        await kyc.addUser(account).should.be.fulfilled;
+        const key = web3.sha3(Date.now() + account);
+        await kyc.addUser(key, account).should.be.fulfilled;
+      }
+    });
+
+    it("should not add user who previously added with presale", async () => {
+      for (const account of accounts.slice(idx2, idx3)) {
+        const key = web3.sha3(Date.now() + account);
+
+        await kyc.addUser(key, account).should.be.fulfilled;
+      }
+
+      for (const account of accounts.slice(idx2, idx3)) {
+        const key = web3.sha3(Date.now() + account);
+
+        await kyc.addUser(key, account).should.be.rejectedWith(EVMThrow);
       }
     });
   });
@@ -60,31 +77,50 @@ contract("KYC", async ([ owner, , , , , , , , ...accounts ]) => {
     const idx3 = accounts.length;
 
     it("should add new user initially", async () => {
-      const amount = ether(Math.floor(Math.random() * 4900));
-
       for (const account of accounts.slice(0, idx0)) {
-        await kyc.addUserWithPreSale(account, amount).should.be.fulfilled;
+        const key = web3.sha3(Date.now() + account);
+        const amount = ether(Math.floor(Math.random() * 4900));
+
+        await kyc.addUserWithPreSale(key, account, amount).should.be.fulfilled;
       }
     });
 
     it("should not add new user after paused", async () => {
-      const amount = ether(Math.floor(Math.random() * 4900));
-
       await kyc.pause();
 
       for (const account of accounts.slice(idx0, idx1)) {
-        await kyc.addUserWithPreSale(account, amount).should.be.rejectedWith(EVMThrow);
+        const key = web3.sha3(Date.now() + account);
+        const amount = ether(Math.floor(Math.random() * 4900));
+
+        await kyc.addUserWithPreSale(key, account, amount).should.be.rejectedWith(EVMThrow);
       }
     });
 
     it("should add new user after paused and unpaused", async () => {
-      const amount = ether(Math.floor(Math.random() * 4900));
-
       await kyc.pause();
       await kyc.unpause();
 
       for (const account of accounts.slice(idx1, idx2)) {
-        await kyc.addUserWithPreSale(account, amount).should.be.fulfilled;
+        const key = web3.sha3(Date.now() + account);
+        const amount = ether(Math.floor(Math.random() * 4900));
+
+        await kyc.addUserWithPreSale(key, account, amount).should.be.fulfilled;
+      }
+    });
+
+    it("should not add user who previously added with presale", async () => {
+      for (const account of accounts.slice(idx2, idx3)) {
+        const key = web3.sha3(Date.now() + account);
+        const amount = ether(Math.floor(Math.random() * 4900));
+
+        await kyc.addUserWithPreSale(key, account, amount).should.be.fulfilled;
+      }
+
+      for (const account of accounts.slice(idx2, idx3)) {
+        const key = web3.sha3(Date.now() + account);
+        const amount = ether(Math.floor(Math.random() * 4900));
+
+        await kyc.addUserWithPreSale(key, account, amount).should.be.rejectedWith(EVMThrow);
       }
     });
   });

--- a/test/KYCTest.js
+++ b/test/KYCTest.js
@@ -1,0 +1,91 @@
+import ether from "./helpers/ether";
+import { advanceBlock } from "./helpers/advanceToBlock";
+import increaseTime, { increaseTimeTo, duration } from "./helpers/increaseTime";
+import latestTime from "./helpers/latestTime";
+import EVMThrow from "./helpers/EVMThrow";
+import { capture, restore } from "./helpers/snapshot";
+import timer from "./helpers/timer";
+
+const BigNumber = web3.BigNumber;
+const eth = web3.eth;
+
+const should = require("chai")
+  .use(require("chai-as-promised"))
+  .use(require("chai-bignumber")(BigNumber))
+  .should();
+
+const KYC = artifacts.require("KYC.sol");
+
+contract("KYC", async ([ owner, , , , , , , , ...accounts ]) => {
+  let kyc;
+
+  beforeEach(async () => {
+    kyc = await KYC.new();
+  });
+
+  describe("Adding user", async () => {
+    const idx0 = accounts.length / 4;
+    const idx1 = accounts.length * 2 / 4;
+    const idx2 = accounts.length * 3 / 4;
+    const idx3 = accounts.length;
+
+    it("should add new user initially", async () => {
+      for (const account of accounts.slice(0, idx0)) {
+        await kyc.addUser(account).should.be.fulfilled;
+      }
+    });
+
+    it("should not add new user after paused", async () => {
+      await kyc.pause();
+
+      for (const account of accounts.slice(idx0, idx1)) {
+        await kyc.addUser(account).should.be.rejectedWith(EVMThrow);
+      }
+    });
+
+    it("should add new user after paused and unpaused", async () => {
+      await kyc.pause();
+      await kyc.unpause();
+
+      for (const account of accounts.slice(idx1, idx2)) {
+        await kyc.addUser(account).should.be.fulfilled;
+      }
+    });
+  });
+
+  describe("Adding user with presaled", async () => {
+    const idx0 = accounts.length / 4;
+    const idx1 = accounts.length * 2 / 4;
+    const idx2 = accounts.length * 3 / 4;
+    const idx3 = accounts.length;
+
+    it("should add new user initially", async () => {
+      const amount = ether(Math.floor(Math.random() * 4900));
+
+      for (const account of accounts.slice(0, idx0)) {
+        await kyc.addUserWithPreSale(account, amount).should.be.fulfilled;
+      }
+    });
+
+    it("should not add new user after paused", async () => {
+      const amount = ether(Math.floor(Math.random() * 4900));
+
+      await kyc.pause();
+
+      for (const account of accounts.slice(idx0, idx1)) {
+        await kyc.addUserWithPreSale(account, amount).should.be.rejectedWith(EVMThrow);
+      }
+    });
+
+    it("should add new user after paused and unpaused", async () => {
+      const amount = ether(Math.floor(Math.random() * 4900));
+
+      await kyc.pause();
+      await kyc.unpause();
+
+      for (const account of accounts.slice(idx1, idx2)) {
+        await kyc.addUserWithPreSale(account, amount).should.be.fulfilled;
+      }
+    });
+  });
+});

--- a/test/PLCCrowdsaleTest.js
+++ b/test/PLCCrowdsaleTest.js
@@ -18,6 +18,7 @@ const PLCCrowdsale = artifacts.require("PLCCrowdsale.sol");
 const PLC = artifacts.require("PLC.sol");
 const RefundVault = artifacts.require("crowdsale/RefundVault.sol");
 const MultiSig = artifacts.require("wallet/MultiSigWallet.sol");
+const KYC = artifacts.require("KYC.sol");
 
 contract(
   "PLCCrowdsale",
@@ -39,7 +40,8 @@ contract(
     let multiSig,
       crowdsale,
       token,
-      vault;
+      vault,
+      kyc;
 
     let now,
       startTime,
@@ -49,6 +51,7 @@ contract(
       afterStartTime;
 
     let deadlines,
+      presaleRate,
       rates;
 
     let maxGuaranteedLimit,
@@ -68,6 +71,7 @@ contract(
       ];
 
       deadlines = [ 1506643200, 1506902400, 1507161600, 1507420800, 1507593600 ];
+      presaleRate = 500;
       rates = [ 240, 230, 220, 210, 200 ];
 
       maxGuaranteedLimit = ether(5000);
@@ -86,8 +90,16 @@ contract(
       vault = await RefundVault.new(multiSig.address, reserveWallet);
       console.log("vault deployed at", vault.address);
 
-      crowdsale = await PLCCrowdsale.new(token.address, vault.address, multiSig.address,reserveWallet);
+      crowdsale = await PLCCrowdsale.new(
+        token.address,
+        vault.address,
+        multiSig.address,
+        reserveWallet,
+      );
       console.log("crowdsale deployed at", crowdsale.address);
+
+      kyc = await KYC.new();
+      console.log("kyc deployed at", kyc.address);
 
       await token.transferOwnership(crowdsale.address);
       await vault.transferOwnership(crowdsale.address);
@@ -124,20 +136,20 @@ now:\t\t\t${ now }
 `);
     });
 
-    describe("testing...", async () => {
-      beforeEach(async () => {
-        // restore
-        await restore(snapshotId);
+    beforeEach(async () => {
+      // restore
+      await restore(snapshotId);
 
-        // backup
-        snapshotId = await capture();
+      // backup
+      snapshotId = await capture();
 
-        // proceed 20 block
-        for (const i of Array(20)) {
-          await advanceBlock();
-        }
-      });
+      // proceed 20 block
+      for (const i of Array(20)) {
+        await advanceBlock();
+      }
+    });
 
+    describe("Crowdsale", async () => {
       // before start
       it("should reject payments before start", async () => {
         await increaseTimeTo(beforeStartTime);
@@ -422,6 +434,15 @@ now:\t\t\t${ now }
         // token pause
         await token.pause().should.be.fulfilled;
       });
+    });
+
+    describe("with KYC", async () => {
+      const idx0 = accounts.length / 4;
+      const idx1 = accounts.length * 2 / 4;
+      const idx2 = accounts.length * 3 / 4;
+      const idx3 = accounts.length;
+
+      it("should add user with presaled", async () => {});
     });
   },
 );

--- a/test/PLCTest.js
+++ b/test/PLCTest.js
@@ -16,12 +16,11 @@ const should = require("chai")
 
 const PLC = artifacts.require("PLC.sol");
 
-contract("PLC Test", async ([ owner, , , , , , , , ...accounts ]) => {
+contract("PLC", async ([ owner, , , , , , , , ...accounts ]) => {
   let token;
 
   beforeEach(async () => {
     token = await PLC.new();
-    console.log("token deployed at", token.address);
   });
 
   // test mintable

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,6 +159,22 @@ babel-generator@^6.26.0:
     source-map "^0.5.6"
     trim-right "^1.0.1"
 
+babel-helper-bindify-decorators@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz#14c19e5f142d7b47f19a52431e52b1ccbc40a330"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
+  dependencies:
+    babel-helper-explode-assignable-expression "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
 babel-helper-call-delegate@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz#ece6aacddc76e41c3461f88bfc575bd0daa2df8d"
@@ -176,6 +192,23 @@ babel-helper-define-map@^6.24.1:
     babel-runtime "^6.26.0"
     babel-types "^6.26.0"
     lodash "^4.17.4"
+
+babel-helper-explode-assignable-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-explode-class@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz#7dc2a3910dee007056e1e31d640ced3d54eaa9eb"
+  dependencies:
+    babel-helper-bindify-decorators "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
 
 babel-helper-function-name@^6.24.1:
   version "6.24.1"
@@ -216,6 +249,16 @@ babel-helper-regex@^6.24.1:
     babel-types "^6.26.0"
     lodash "^4.17.4"
 
+babel-helper-remap-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
 babel-helper-replace-supers@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz#bf6dbfe43938d17369a213ca8a8bf74b6a90ab1a"
@@ -245,6 +288,89 @@ babel-plugin-check-es2015-constants@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-syntax-async-functions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
+babel-plugin-syntax-async-generators@^6.5.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz#6bc963ebb16eccbae6b92b596eb7f35c342a8b9a"
+
+babel-plugin-syntax-class-constructor-call@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz#9cb9d39fe43c8600bec8146456ddcbd4e1a76416"
+
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
+babel-plugin-syntax-decorators@^6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+
+babel-plugin-syntax-exponentiation-operator@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+
+babel-plugin-syntax-export-extensions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz#70a1484f0f9089a4e84ad44bac353c95b9b12721"
+
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
+babel-plugin-syntax-trailing-function-commas@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
+
+babel-plugin-transform-async-generator-functions@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz#f058900145fd3e9907a6ddf28da59f215258a5db"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-generators "^6.5.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-functions "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-constructor-call@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz#80dc285505ac067dcb8d6c65e2f6f11ab7765ef9"
+  dependencies:
+    babel-plugin-syntax-class-constructor-call "^6.18.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-decorators@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz#788013d8f8c6b5222bdf7b344390dfd77569e24d"
+  dependencies:
+    babel-helper-explode-class "^6.24.1"
+    babel-plugin-syntax-decorators "^6.13.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-types "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
@@ -414,6 +540,28 @@ babel-plugin-transform-es2015-unicode-regex@^6.24.1:
     babel-runtime "^6.22.0"
     regexpu-core "^2.0.0"
 
+babel-plugin-transform-exponentiation-operator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
+  dependencies:
+    babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
+    babel-plugin-syntax-exponentiation-operator "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-export-extensions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz#53738b47e75e8218589eea946cbbd39109bbe653"
+  dependencies:
+    babel-plugin-syntax-export-extensions "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.22.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
+
 babel-plugin-transform-regenerator@^6.24.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
@@ -463,6 +611,33 @@ babel-preset-es2015@^6.24.1:
     babel-plugin-transform-es2015-typeof-symbol "^6.22.0"
     babel-plugin-transform-es2015-unicode-regex "^6.24.1"
     babel-plugin-transform-regenerator "^6.24.1"
+
+babel-preset-stage-1@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz#7692cd7dcd6849907e6ae4a0a85589cfb9e2bfb0"
+  dependencies:
+    babel-plugin-transform-class-constructor-call "^6.24.1"
+    babel-plugin-transform-export-extensions "^6.22.0"
+    babel-preset-stage-2 "^6.24.1"
+
+babel-preset-stage-2@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz#d9e2960fb3d71187f0e64eec62bc07767219bdc1"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-plugin-transform-class-properties "^6.24.1"
+    babel-plugin-transform-decorators "^6.24.1"
+    babel-preset-stage-3 "^6.24.1"
+
+babel-preset-stage-3@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz#836ada0a9e7a7fa37cb138fb9326f87934a48395"
+  dependencies:
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-generator-functions "^6.24.1"
+    babel-plugin-transform-async-to-generator "^6.24.1"
+    babel-plugin-transform-exponentiation-operator "^6.24.1"
+    babel-plugin-transform-object-rest-spread "^6.22.0"
 
 babel-register@^6.26.0:
   version "6.26.0"


### PR DESCRIPTION
### KYC, Presale, Pausable Added

#### changes
 - KYC contract 
   - handling KYC and Presale simultaneously
   - register address with / without key (result of `web3.sha3()`), and with / without Presale
   - check KYC register functions (see below)
 - Crowdsale inherits Pausable contract: In case of hard fork, pause crowdsale
   - `Pausable.whenNotPaused` modifier applied to `buyTokens` function
 - Crowdsale inherits KYC contract
   - `KYC.onlyRegistered` modifier applied to `Crowdsale.buyTokens` 
   - currently `KYC.onlyRegistered` modifier accept registered address __without key__. if KYC with key is required, change it to `KYC.onlyRegisteredWithKey` modifier



### KYC 
1. fields
`mapping (address => bool)    public registeredAddress;`
`mapping (bytes32 => address) public registeredKey;`
`mapping (address => uint256) public registeredAmount;`

2.  registration
 - register user by address
 - register user by address and key (result of `web3.sha3`)

3. register  functions
` function register(address _addr)    public    onlyOwner    whenNotPaused`
`function registerWithPreSale(    address _addr,    uint256 _amount)    public    onlyOwner    whenNotPaused`
`function registerWithKey(    bytes32 _key,    address _addr)    public    onlyOwner    whenNotPaused`
`function registerWithKeyAndPreSale(    bytes32 _key,    address _addr,    uint256 _amount)    public    onlyOwner    whenNotPaused`

4. const public functions
`function getAddress(bytes32 _key) public constant returns (address)`
`function isRegistered(address _addr) public constant returns (bool)`
`function isRegisteredWithKey(bytes32 _key, address _addr) public constant  returns (bool)`