### PR TITLE
refund when forked

### DIFF
--- a/contracts/PLCCrowdsale.sol
+++ b/contracts/PLCCrowdsale.sol
@@ -227,6 +227,11 @@ contract PLCCrowdsale is Ownable, SafeMath, Pausable, KYC {
     token.finishMinting();
   }
 
+  function finalizeWhenForked() onlyOwner whenPaused {
+    vault.enableRefunds();
+    token.finishMinting();
+  }
+
   // if crowdsale is unsuccessful, investors can claim refunds here
   function claimRefund() {
     require(isFinalized);


### PR DESCRIPTION
When ethereum is forked, all ether deposit in not supported fork need to be refunded.

modifier: onlyOwner, whenPaused
function: enableRefund(), finishMinting()